### PR TITLE
Adapt code to work with Mathesar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:16-alpine
-LABEL maintainer="requarks.io"
+LABEL maintainer="centerofci.org"
 
-RUN mkdir -p /wiki-update && \
-    chown -R node:node /wiki-update
+ARG workdir="/mathesar-update"
 
-WORKDIR /wiki-update
+RUN mkdir -p $workdir && \
+    chown -R node:node $workdir
+
+WORKDIR $workdir
 
 COPY index.js index.js
 COPY LICENSE LICENSE

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ async function upgrade (name, version) {
 
   console.info('Pulling latest Mathesar image...')
   await new Promise((resolve, reject) => {
-    dk.pull(`ghcr.io/centerofci/mathesar:${version}`, (err, stream) => {
+    dk.pull(`${ghcrUrl}:${version}`, (err, stream) => {
       if (err) { return reject(err) }
       dk.modem.followProgress(stream, (err) => {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "wiki-update-companion",
+  "name": "mathesar-update-companion",
   "version": "2.1.0",
-  "description": "Automated Update Companion for Wiki.js",
+  "description": "Automated Update Companion for Mathesar",
   "main": "index.js",
   "private": true,
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/requarks/wiki-update-companion.git"
+    "url": "git+https://github.com/centerofci/mathesar-update-companion.git"
   },
-  "author": "Nicolas Giard",
+  "author": "Dominykas Mostauskis",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/requarks/wiki-update-companion/issues"
+    "url": "https://github.com/centerofci/mathesar-update-companion/issues"
   },
-  "homepage": "https://github.com/requarks/wiki-update-companion#readme",
+  "homepage": "https://github.com/centerofci/mathesar-update-companion",
   "dependencies": {
     "dockerode": "3.3.4",
     "fastify": "4.9.2"


### PR DESCRIPTION
Issue in Mathesar repo: https://github.com/centerofci/mathesar/issues/2194

Changed hardcoded strings and variable names from being Wiki.js-specific to being Mathesar-specific.

Wiki.js uses Github Packages to publish its Docker images. I changed the relevant URLs as if Mathesar was doing the same (even though it's not). I tried to minimize functional changes. That's something to update once our images are published (probably in another PR).